### PR TITLE
Potential fix for code scanning alert no. 2: DOM text reinterpreted as HTML

### DIFF
--- a/explorer/static/explorer.js
+++ b/explorer/static/explorer.js
@@ -71,7 +71,7 @@ elements.searchForm?.addEventListener('submit', async (e) => {
             try {
                 const blockResponse = await fetchWithTimeout(`/api/block/${query}?network=${state.network}`);
                 if (blockResponse.ok) {
-                    window.location.href = `/block/${query}`;
+                    window.location.href = `/block/${encodeURIComponent(query)}`;
                     return;
                 }
             } catch (error) {
@@ -90,11 +90,11 @@ elements.searchForm?.addEventListener('submit', async (e) => {
         
         // Redirect based on result type
         if ('balance' in data) {
-            window.location.href = `/address/${query}`;
+            window.location.href = `/address/${encodeURIComponent(query)}`;
         } else if ('transactions' in data) {
-            window.location.href = `/block/${query}`;
+            window.location.href = `/block/${encodeURIComponent(query)}`;
         } else {
-            window.location.href = `/transaction/${query}`;
+            window.location.href = `/transaction/${encodeURIComponent(query)}`;
         }
     } catch (error) {
         console.error('Search error:', error);


### PR DESCRIPTION
Potential fix for [https://github.com/BronzonTech-Cloud/rootchain/security/code-scanning/2](https://github.com/BronzonTech-Cloud/rootchain/security/code-scanning/2)

To fix the issue, the user input (`query`, derived from `elements.searchInput?.value`), should be safely encoded before inclusion in any client-side navigation or output. For URLs, JavaScript provides the `encodeURIComponent` function, which escapes all characters with special meaning in URLs, thereby preventing control characters from being interpreted in a potentially dangerous way (such as prematurely breaking out of a string or introducing code injection vectors).

The best fix is to wrap all uses of `${query}` inserted into URLs with `encodeURIComponent(query)`, namely at:
- line 74: window.location.href = `/block/${query}`;
- line 93: window.location.href = `/address/${query}`;
- line 97: window.location.href = `/transaction/${query}`;

No imports are needed, as this is a built-in JS function. Only those usages need changing in explorer/static/explorer.js.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
