### PR TITLE
Potential fix for code scanning alert no. 6: Prototype-polluting assignment

### DIFF
--- a/developer-portal/app/api/keys/route.ts
+++ b/developer-portal/app/api/keys/route.ts
@@ -80,7 +80,11 @@ export async function PATCH(request: Request) {
   try {
     const { id, status } = await request.json()
     
-    if (!id || !apiKeys[id]) {
+    if (
+      !id ||
+      ["__proto__", "prototype", "constructor"].includes(id) ||
+      !apiKeys[id]
+    ) {
       return NextResponse.json(
         { error: 'Invalid API key ID' },
         { status: 400 }


### PR DESCRIPTION
Potential fix for [https://github.com/BronzonTech-Cloud/rootchain/security/code-scanning/6](https://github.com/BronzonTech-Cloud/rootchain/security/code-scanning/6)

To robustly fix this issue without changing intended functionality, we should prevent prototype-polluting keys like `__proto__`, `prototype`, or `constructor` from being used as object keys. The best fix that is minimally invasive here is to explicitly check the `id` string value before using it as a key, rejecting or erroring if it matches any of these dangerous values.  

Specifically, in the PATCH route, after extracting `id` from `request.json()`, add a check:
```ts
if (["__proto__", "prototype", "constructor"].includes(id)) {
  return NextResponse.json(
    { error: 'Invalid API key ID' },
    { status: 400 }
  )
}
```
Do this right before you use `apiKeys[id]`. No new dependencies are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
